### PR TITLE
default off for markdown_enable_insert_mode_mappings

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -24,7 +24,7 @@ if !exists('g:markdown_enable_insert_mode_mappings')
   if exists('g:markdown_include_insert_mode_default_mappings')
     let g:markdown_enable_insert_mode_mappings = g:markdown_include_insert_mode_default_mappings
   else
-    let g:markdown_enable_insert_mode_mappings = 1
+    let g:markdown_enable_insert_mode_mappings = 0
   endif
 endif
 


### PR DESCRIPTION
For those with `<leader>` set to `<space>`, having this as a default makes it difficult to write anything without invoking the sub-edit mode. Seems like something that may be best left off by default.
