### PR TITLE
add option to enable insert mode leader mappings with a default off off ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,25 @@ If you like this plugin, then consider to:
 I would use this section until I have a proper documentation
 
 ### Configuration
-* `let g:markdown_include_jekyll_support = 1` to load support to Jekyll files (default: 1)
-* `let g:markdown_enable_folding = 1` to use the fold expression `markdown#FoldLevelOfLine` to fold markdown files, this is disabled by default because it's a huge performance hit even when folding is disabled with `nofoldenable` option (default: 0)
-* `let g:markdown_enable_mappings = 1` to load default mappings (default: 1)
-  * `let g:markdown_enable_insert_mode_mappings = 1` to load also insert mode mappings (default: 1)
+* `let g:markdown_include_jekyll_support = 0` to enable/disable support for Jekyll files (default: 1)
+* `let g:markdown_enable_folding = 1` to enable/disable the fold expression `markdown#FoldLevelOfLine` to fold markdown files, this is disabled by default because it's a huge performance hit even when folding is disabled with `nofoldenable` option (default: 0)
+* `let g:markdown_enable_mappings = 0` to enable/disable default mappings (default: `1`)
+  * `let g:markdown_enable_insert_mode_mappings = 0` to enable/disable insert mode mappings (default: `1`)
+  * `let g:markdown_enable_insert_mode_leader_mappings = 1` to enable/disable insert mode leader mappings (default: `0`)
 
-### Default Mappings
-All default mappings are local to markdown buffers
+### Default Mappings (normal and visual mode)
+_mappings are local to markdown buffers_
 * `<Space>` (`NORMAL_MODE`) switch status of things:
   * A list item `* item` becomes a check list item `* [ ] item`
   * A check list item `* [ ] item` becomes a checked list item `* [x] item`
   * A checked list item `* [x] item` becomes a list item `* item`
-* `<Leader>ft` (`NORMAL_MODE`, `INSERT_MODE`) format the current table
-* `<Leader>e` (`NORMAL_MODE`, `VISUAL_MODE`, `INSERT_MODE`) `:MarkdownEditCodeBlock` edit the current code block in another buffer with a guessed file type. The guess is based on the start of the range for `VISUAL_MODE`. If it's not possibile to guess (you are not in a recognizable code block like a fenced code block) then the default is `markdown`. If it's not possibile to guess and the current range is a single line and the line is empty then a new code block is created. It's asked to the user the file type of the new code block. The default file type is `markdown`.
+* `<Leader>ft` (`NORMAL_MODE`) format the current table
+* `<Leader>e` (`NORMAL_MODE`, `VISUAL_MODE`) `:MarkdownEditCodeBlock` edit the current code block in another buffer with a guessed file type. The guess is based on the start of the range for `VISUAL_MODE`. If it's not possibile to guess (you are not in a recognizable code block like a fenced code block) then the default is `markdown`. If it's not possibile to guess and the current range is a single line and the line is empty then a new code block is created. It's asked to the user the file type of the new code block. The default file type is `markdown`.
+
+### Optional Mappings (insert mode)
+_mappings are local to markdown buffers_
+* `<Leader>ft` (`INSERT_MODE`) same as `NORMAL_MODE` `<Leader>ft` with an additional mapping for `INSERT_MODE`
+* `<Leader>e` (`INSERT_MODE`) same as `NORMAL_MODE` and `VISUAL_MODE` `<leader>e` with an additional mapping for `INSERT_MODE`
 
 ### Motions
 * `]]` start of the next header

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -24,8 +24,12 @@ if !exists('g:markdown_enable_insert_mode_mappings')
   if exists('g:markdown_include_insert_mode_default_mappings')
     let g:markdown_enable_insert_mode_mappings = g:markdown_include_insert_mode_default_mappings
   else
-    let g:markdown_enable_insert_mode_mappings = 0
+    let g:markdown_enable_insert_mode_mappings = 1
   endif
+endif
+
+if !exists('g:markdown_enable_insert_mode_leader_mappings')
+    let g:markdown_enable_insert_mode_leader_mappings = 0
 endif
 
 " }}}
@@ -149,10 +153,10 @@ if g:markdown_enable_mappings
   " Leader mappings
   nnoremap <buffer> <Leader>e :MarkdownEditBlock<CR>
   vnoremap <buffer> <Leader>e :MarkdownEditBlock<CR>
-
   nnoremap <silent> <buffer> <Leader>ft  :call markdown#FormatTable()<CR>
 
-  if g:markdown_enable_insert_mode_mappings
+  " Insert Mode mappings
+  if g:markdown_enable_insert_mode_leader_mappings
     inoremap <buffer> <Leader>e <Esc>:MarkdownEditBlock<CR>
     inoremap <silent> <buffer> <Leader>ft  <Esc>:call markdown#FormatTable()<CR>a
   endif


### PR DESCRIPTION
This is a follow-up to #8 which defaulted to having `g:markdown_enable_insert_mode_mappings` disabled.

After further investigation, I've found that there is a more friendly avenue as follows:
- Add a new option `g:markdown_enable_insert_mode_leader_mappings` which has a default of `0`.
- Default `g:markdown_enable_insert_mode_mappings` to `1` like it was before.

This means that OOTB, a user gets the nice default handling of:
1. [un]indenting empty list items on [s-]tab.
2. removing empty list items on <CR>.
3. formatting tables.
4. normal and visual mode leader mappings for block editing (<leader>e) and table formatting (<leader>ft).

This also means that if a user wants to have the insert mode leader mappings, they only need to do:

``` vimscript
let g:markdown_enable_insert_mode_leader_mappings = 1
```

Documentation has also been updated to match updated settings.
