### PR TITLE
#39: modified JumpToHeader to accept counts and avoid polluting search history

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -93,16 +93,23 @@ endif
 " {{{ FUNCTIONS
 
 function! s:JumpToHeader(forward, visual)
+  let cnt = v:count1
+  let save = @/
   let pattern = '\v^#{1,6}.*$|^.+\n%(\-+|\=+)$'
   if a:visual
     normal! gv
   endif
   if a:forward
-    let direction = '/'
+    let motion = '/' . pattern
   else
-    let direction = '?'
+    let motion = '?' . pattern
   endif
-  execute 'silent normal! ' . direction . pattern . "\n"
+  while cnt > 0
+	  silent! execute motion
+	  let cnt = cnt - 1
+  endwhile
+  call histdel('/', -1)
+  let @/ = save
 endfunction
 
 function! s:Indent(indent)
@@ -143,8 +150,8 @@ command! -nargs=0 -range MarkdownEditBlock :<line1>,<line2>call markdown#EditBlo
 
 if g:markdown_enable_mappings
   " Jumping around
-  noremap <silent> <buffer> <script> ]] :call <SID>JumpToHeader(1, 0)<CR>
-  noremap <silent> <buffer> <script> [[ :call <SID>JumpToHeader(0, 0)<CR>
+  noremap <silent> <buffer> <script> ]] :<C-u>call <SID>JumpToHeader(1, 0)<CR>
+  noremap <silent> <buffer> <script> [[ :<C-u>call <SID>JumpToHeader(0, 0)<CR>
   vnoremap <silent> <buffer> <script> ]] :<C-u>call <SID>JumpToHeader(1, 1)<CR>
   vnoremap <silent> <buffer> <script> [[ :<C-u>call <SID>JumpToHeader(0, 1)<CR>
   noremap <silent> <buffer> <script> ][ <nop>


### PR DESCRIPTION
Notes:

- I had to add `<C-u>` to the normal mode mappings as well before `[[` started accepting a count properly, following suggestions from http://vi.stackexchange.com/q/4366/205
- I used `:silent! execute` since:
 1. @romainl used it
 2. The help for [`:silent`](http://vimhelp.appspot.com/various.txt.html#%3Asilent) uses `:silent exe "normal ..."`, so presumably that's the preferred way
 3. And `:/`, `:?` seems to work well, so calling `normal` seemed unnecessary.

I'm not generally used to Github pull requests (messed up the only one I tried before), so if I should have done something differently (use a branch or something), my apologies.