### PR TITLE
Fix SwitchStatus() to recognize list with `-`

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -497,16 +497,16 @@ endfunction
 " {{{ SWITCH STATUS
 function! markdown#SwitchStatus()
   let current_line = getline('.')
-  if match(current_line, '^\s*[*-+] \[ \]') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\) \[ \]', '\1 [x]', ''))
+  if match(current_line, '^\s*[*\-+] \[ \]') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[ \]', '\1 [x]', ''))
     return
   endif
-  if match(current_line, '^\s*[*-+] \[x\]') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\) \[x\]', '\1', ''))
+  if match(current_line, '^\s*[*\-+] \[x\]') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[x\]', '\1', ''))
     return
   endif
-  if match(current_line, '^\s*[*-+] \(\[[x ]\]\)\@!') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\)', '\1 [ ]', ''))
+  if match(current_line, '^\s*[*\-+] \(\[[x ]\]\)\@!') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\)', '\1 [ ]', ''))
     return
   endif
   if match(current_line, '^\s*#\{1,5}\s') >= 0

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -55,9 +55,9 @@ endif
 
 setlocal textwidth=0
 setlocal ts=2 sw=2 expandtab smarttab
-setlocal comments=b:*,b:-,b:+,n:> commentstring=>\ %s
+setlocal comments=f:*,f:-,f:+,n:> commentstring=>\ %s
 setlocal formatoptions+=tcrqon formatoptions-=wa
-setlocal formatlistpat="^\s*\d\.\s\+"
+setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+-\\*]\\s\\+
 
 " Enable spelling and completion based on dictionary words
 if &spelllang !~# '^\s*$' && g:markdown_enable_spell_checking


### PR DESCRIPTION
`-` needs to be escaped in vim regex. Fix #44.