### PR TITLE
Fix formatlistpat not work for ordered list

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -497,16 +497,16 @@ endfunction
 " {{{ SWITCH STATUS
 function! markdown#SwitchStatus()
   let current_line = getline('.')
-  if match(current_line, '^\s*[*-+] \[ \]') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\) \[ \]', '\1 [x]', ''))
+  if match(current_line, '^\s*[*\-+] \[ \]') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[ \]', '\1 [x]', ''))
     return
   endif
-  if match(current_line, '^\s*[*-+] \[x\]') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\) \[x\]', '\1', ''))
+  if match(current_line, '^\s*[*\-+] \[x\]') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[x\]', '\1', ''))
     return
   endif
-  if match(current_line, '^\s*[*-+] \(\[[x ]\]\)\@!') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*-+]\)', '\1 [ ]', ''))
+  if match(current_line, '^\s*[*\-+] \(\[[x ]\]\)\@!') >= 0
+    call setline('.', substitute(current_line, '^\(\s*[*\-+]\)', '\1 [ ]', ''))
     return
   endif
   if match(current_line, '^\s*#\{1,5}\s') >= 0

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -55,9 +55,9 @@ endif
 
 setlocal textwidth=0
 setlocal ts=2 sw=2 expandtab smarttab
-setlocal comments=b:*,b:-,b:+,n:> commentstring=>\ %s
+setlocal comments=f:*,f:-,f:+,n:> commentstring=>\ %s
 setlocal formatoptions+=tcrqon formatoptions-=wa
-setlocal formatlistpat="^\s*\d\.\s\+"
+setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+-\\*]\\s\\+
 
 " Enable spelling and completion based on dictionary words
 if &spelllang !~# '^\s*$' && g:markdown_enable_spell_checking

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -55,7 +55,7 @@ endif
 
 setlocal textwidth=0
 setlocal ts=2 sw=2 expandtab smarttab
-setlocal comments=f:*,f:-,f:+,n:> commentstring=>\ %s
+setlocal comments=f:*,f:-,f:+,n:>,se:``` commentstring=>\ %s
 setlocal formatoptions+=tcrqon formatoptions-=wa
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+-\\*]\\s\\+
 


### PR DESCRIPTION
1. Fix formatlistpat to work with ordered list.
    Before formatting with `gq` command:
    ```
    List Header:
      1. Consectetur ipsa dolore nesciunt id ipsam sed ullam? In ut cumque hic consequatur veritatis. Nihil consequuntur tenetur aliquid illo non!
      2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent aliquet metus sed metus vulputate efficitur!
    ```
    After formatting with `gq` command:
    ```
    List Header:
      1. Consectetur ipsa dolore nesciunt id ipsam sed ullam? In ut cumque hic
         consequatur veritatis. Nihil consequuntur tenetur aliquid illo non!
      2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent aliquet
         metus sed metus vulputate efficitur!
    ```
     
2. Long list item is broken into 2 items when the list is formated with `gq`:
    Before formating with `gq` command:
    ```
    List Header:
      * Consectetur ipsa dolore nesciunt id ipsam sed ullam? In ut cumque hic consequatur veritatis. Nihil consequuntur tenetur aliquid illo non!
      * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent aliquet metus sed metus vulputate efficitur!
    ```
    After formating with `gq` command:
    ```
    List Header:
      * Consectetur ipsa dolore nesciunt id ipsam sed ullam? In ut cumque hic
        consequatur veritatis. Nihil consequuntur tenetur aliquid illo non!
      * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
        aliquet metus sed metus vulputate efficitur!
    ```
3. [Fix] Horizontal rules are not joined with the header anymore:

    ```
    Big Header
    *****************
    ```
    If the text above is formatted with `gq`, the `**********` line will be joined with the line above:
    ```
    Big Header *****************
    ```
    This commit fixes this error.
4. [Fix] Similarly to 3., if `gq` is executed on a codeblock, it would join the starting ``` with the first line in the code block and the last line with the ending ```:

    ```
    ` ` `Code block line 1
    Code block line 2` ` `
    ```
    The fix will leave it intact after executing `gq` on the codeblock.