### PR TITLE
Add conceal support for markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ I would use this section until I have a proper documentation
   * `let g:markdown_enable_insert_mode_leader_mappings = 1` to enable insert mode leader mappings (disabled by default with: `0`)
 * `let g:markdown_enable_spell_checking = 0` to disable spell checking (enabled by default with: `1`)
 * `let g:markdown_enable_input_abbreviations = 0` to disable abbreviations for punctuations and emoticons (enabled by default with: `1`)
+* `let g:markdown_enable_conceal = 1` to enable conceal for italic, bold, inline-code and link (disabled by default with: `0`)
 
 ### Default Mappings (normal and visual mode)
 _mappings are local to markdown buffers_

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -15,6 +15,16 @@ if !exists('g:markdown_flavor')
   let g:markdown_flavor = 'github'
 endif
 
+if exists('g:markdown_enable_conceal') && g:markdown_enable_conceal
+    let b:markdown_concealends = 'concealends'
+    let b:markdown_conceal = 'conceal'
+    set conceallevel=2
+    set concealcursor=
+else
+    let b:markdown_concealends = ''
+    let b:markdown_conceal = ''
+endif
+
 syn spell toplevel
 syn sync fromstart
 syn case ignore
@@ -28,32 +38,40 @@ syn cluster markdownInline contains=
   \ markdownEmailLinkInText,markdownLinkContainer,markdownXmlComment,
   \ markdownXmlElement,markdownXmlEmptyElement,markdownXmlEntities
 
-syn region markdownItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|_\|^\)\@<=\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*"
-  \ contains=@markdownInline
-syn region markdownItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|\*\|^\)\@<=_\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!_"
-  \ contains=@markdownInline
+execute 'syn region markdownItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|_\|^\)\@<=\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
+execute 'syn region markdownItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|\*\|^\)\@<=_\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!_" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
 
-syn region markdownBold matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|__\|^\)\@<=\*\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\*\)\@<!\*\*"
-  \ contains=@markdownInline
-syn region markdownBold matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|\*\*\|^\)\@<=__\%(\s\|_\|$\)\@!" end="\%(\s\|__\)\@<!__"
-  \ contains=@markdownInline
+execute 'syn region markdownBold matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|__\|^\)\@<=\*\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\*\)\@<!\*\*" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
+execute 'syn region markdownBold matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|\*\*\|^\)\@<=__\%(\s\|_\|$\)\@!" end="\%(\s\|__\)\@<!__" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
 
-syn region markdownBoldItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|_\|^\)\@<=\*\*\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*\*\*"
-  \ contains=@markdownInline
-syn region markdownBoldItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|\*\|^\)\@<=___\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!___"
-  \ contains=@markdownInline
-syn region markdownBoldItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|_\|^\)\@<=\*\*_\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!_\*\*"
-  \ contains=@markdownInline
-syn region markdownBoldItalic matchgroup=markdownInlineDelimiter
-  \ start="\%(\s\|\*\|^\)\@<=__\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*__"
-  \ contains=@markdownInline
+execute 'syn region markdownBoldItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|_\|^\)\@<=\*\*\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*\*\*" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
+execute 'syn region markdownBoldItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|\*\|^\)\@<=___\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!___" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
+execute 'syn region markdownBoldItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|_\|^\)\@<=\*\*_\%(\s\|_\|$\)\@!" end="\%(\s\|_\)\@<!_\*\*" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
+execute 'syn region markdownBoldItalic matchgroup=markdownInlineDelimiter '
+  \ . 'start="\%(\s\|\*\|^\)\@<=__\*\%(\s\|\*\|$\)\@!" end="\%(\s\|\*\)\@<!\*__" '
+  \ . 'contains=@markdownInline '
+  \ . b:markdown_concealends
 
 syn match markdownStrike /\%(\\\)\@<!\~\~\%(\S\)\@=\_.\{-}\%(\S\)\@<=\~\~/ contains=markdownStrikeDelimiter,@markdownInline
 syn match markdownStrikeDelimiter /\~\~/ contained
@@ -67,8 +85,8 @@ syn match markdownStrikeDelimiter /\~\~/ contained
 "       # this is not a fenced code block but it's a code block
 "       def ruby;
 "       ```
-syn region markdownInlineCode matchgroup=markdownCodeDelimiter start=/\%(`\)\@<!`/ end=/`/ keepend contains=@NoSpell
-syn region markdownInlineCode matchgroup=markdownCodeDelimiter start=/\%(`\)\@<!`\z(`\+\)/ end=/`\z1/ keepend contains=@NoSpell
+execute 'syn region markdownInlineCode matchgroup=markdownCodeDelimiter start=/\%(`\)\@<!`/ end=/`/ keepend contains=@NoSpell ' . b:markdown_concealends
+execute 'syn region markdownInlineCode matchgroup=markdownCodeDelimiter start=/\%(`\)\@<!`\z(`\+\)/ end=/`\z1/ keepend contains=@NoSpell ' . b:markdown_concealends
 
 " case insensitive
 " preceded by something that is not a word
@@ -218,7 +236,8 @@ execute 'syn match markdownLinkUrlContainer contained '
   \ . 'contains=markdownLinkUrl,markdownLinkTitleSingleQuoted,markdownLinkTitleDoubleQuoted '
   \ . '/'
   \ . b:markdown_syntax_round_brackets_block
-  \ . '/'
+  \ . '/ '
+  \ . b:markdown_conceal
 
 execute 'syn match markdownLinkUrl contained '
   \ . 'contains=@NoSpell '
@@ -242,11 +261,13 @@ execute 'syn match markdownLinkUrl contained '
   \ . '\%(\s\+["'']\|)\|\n\)\@='
   \ . '/'
 
-syn region markdownLinkTitleSingleQuoted start=/\s*'/ skip=/\\'/ end=/'\_s*/ display
-  \ keepend contained contains=@markdownInline
+execute 'syn region markdownLinkTitleSingleQuoted start=/\s*''/ skip=/\\''/ end=/''\_s*/ display '
+  \ . 'keepend contained contains=@markdownInline '
+  \ . b:markdown_conceal
 
-syn region markdownLinkTitleDoubleQuoted start=/\s*"/ skip=/\\"/ end=/"\_s*/ display
-  \ keepend contained contains=@markdownInline
+execute 'syn region markdownLinkTitleDoubleQuoted start=/\s*"/ skip=/\\"/ end=/"\_s*/ display '
+  \ . 'keepend contained contains=@markdownInline '
+  \ . b:markdown_conceal
 
 syn match markdownXmlComment /\c<\!--\_.\{-}-->/ contains=@NoSpell
 syn match markdownXmlElement /\c<\([-A-Z0-9_$?!:,.]\+\)[^>]\{-}>\_.\{-}<\/\1>/ contains=@NoSpell


### PR DESCRIPTION
Add g:markdown_enable_conceal as a switch to turn on conceal feature.
Now the conceal feature supports:
1. Bold, Italic, and BoldItalic;
2. Inline code block;
3. Link.

Signed-off-by: Le Tan <tamlokveer@gmail.com>