### PR TITLE
Don't treat lines that start with 1 char as lists

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -57,7 +57,7 @@ setlocal textwidth=0
 setlocal ts=2 sw=2 expandtab smarttab
 setlocal comments=b:*,b:-,b:+,n:>,se:``` commentstring=>\ %s
 setlocal formatoptions=tron
-setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+-\\*]\\s\\+
+setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+\\-*]\\s\\+
 setlocal nolisp
 setlocal autoindent
 


### PR DESCRIPTION
This fixes #70. I am surprised that this hasn't come up before, however, so I would love someone else to confirm that this doesn't break cases I haven't tested. Maybe I only noticed it because I have turned `textwidth` back to my normal value.

Part of the previous `formatlistpat` regex doesn't appear to match what I think it should. Specifically this: `[+-\\*]`. That is supposed to match one of `+`, `-`, or `*`. However when I run that on my own vim v8.0, it does not. That double escape I think is supposed to become either `[+-*]` or `[+-\*]`. When I try to run it via `/` it doesn't match what I expect. I think that it is interpreting `-` as a range operator or something funky like that.

This appears to correct the problem for me, though I haven't run it against your goldens.
