### PR TITLE
Indent lenght

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This section will contain preliminary documentation until full documentation is 
 * `let g:markdown_enable_spell_checking = 0` to disable spell checking (enabled by default with: `1`)
 * `let g:markdown_enable_input_abbreviations = 0` to disable abbreviations for punctuation and emoticons (enabled by default with: `1`)
 * `let g:markdown_enable_conceal = 1` to enable conceal for italic, bold, inline-code and link text (disabled by default with: `0`)
+* `let g:markdown_indent_lenght = 4` to define the strict Markdown indentation length. Without this, level-based syntax highlighting will not work. The default indentation length is `2` to match the GitHub Markdown flavor.
 
 ### Default Mappings (normal and visual mode)
 _mappings are local to markdown buffers_

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -6,6 +6,10 @@ if !exists('g:markdown_flavor')
   let g:markdown_flavor = 'github'
 endif
 
+if !exists('g:markdown_indent_lenght')
+  let g:markdown_indent_lenght = 2
+endif
+
 if !exists('g:markdown_enable_folding')
   let g:markdown_enable_folding = 0
 endif
@@ -54,7 +58,7 @@ endif
 " {{{ OPTIONS
 
 setlocal textwidth=0
-setlocal ts=2 sw=2 expandtab smarttab
+execute 'setlocal ts=' . g:markdown_indent_lenght . ' sw='  . g:markdown_indent_lenght . ' expandtab smarttab'
 setlocal comments=b:*,b:-,b:+,n:>,se:``` commentstring=>\ %s
 setlocal formatoptions=tron
 setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\\|^\\s*[+-\\*]\\s\\+

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -15,6 +15,15 @@ if !exists('g:markdown_flavor')
   let g:markdown_flavor = 'github'
 endif
 
+" default github indent lenght
+if !exists('g:markdown_indent_lenght')
+  let g:markdown_indent_lenght = 2
+  let g:markdown_indent_codeblock = 6
+" strict markdown indent lenght
+elseif g:markdown_indent_lenght == 4
+  let g:markdown_indent_codeblock = 4
+endif
+
 if exists('g:markdown_enable_conceal') && g:markdown_enable_conceal
     let b:markdown_concealends = 'concealends'
     let b:markdown_conceal = 'conceal'
@@ -360,8 +369,8 @@ execute 'syn match markdownTableHeader contained contains=@markdownInline '
 " {{{ NESTED BLOCKS
 
 for s:level in range(1, 16)
-  let s:indented_as_content = '\%( \{' . (2*s:level) . '}\|\t\{' . (s:level) . '}\)'
-  let s:indented_as_container = '\%( \{' . (2*(s:level-1)) . '}\|\t\{' . (s:level-1) . '}\)'
+  let s:indented_as_content = '\%( \{' . (g:markdown_indent_lenght*s:level) . '}\|\t\{' . (s:level) . '}\)'
+  let s:indented_as_container = '\%( \{' . (g:markdown_indent_lenght*(s:level-1)) . '}\|\t\{' . (s:level-1) . '}\)'
   let s:preceded_by_separator = '^\s*\n'
 
   execute 'syn region markdownListItemAtLevel' . (s:level) . ' '
@@ -404,7 +413,7 @@ for s:level in range(1, 16)
     \ . 'start='
     \ .   '/'
     \ .     (s:preceded_by_separator)
-    \ .     '\z( \{' . (2*s:level) . ',}\|\t\{' . (s:level) . ',}\)*```\%(`*\).*$'
+    \ .     '\z( \{' . (g:markdown_indent_lenght*s:level) . ',}\|\t\{' . (s:level) . ',}\)*```\%(`*\).*$'
     \ .   '/ '
     \ . 'end=/^\z1```\%(`*\)\s*$/'
   execute 'syn region markdownFencedCodeBlockInListItemAtLevel' . (s:level) . ' '
@@ -413,14 +422,14 @@ for s:level in range(1, 16)
     \ . 'start='
     \ .   '/'
     \ .     (s:preceded_by_separator)
-    \ .     '\z( \{' . (2*s:level) . ',}\|\t\{' . (s:level) . ',}\)*\~\~\~\%(\~*\).*$'
+    \ .     '\z( \{' . (g:markdown_indent_lenght*s:level) . ',}\|\t\{' . (s:level) . ',}\)*\~\~\~\%(\~*\).*$'
     \ .   '/ '
     \ . 'end=/^\z1\~\~\~\%(\~*\)\s*$/'
   execute 'hi def link markdownFencedCodeBlockInListItemAtLevel' . (s:level) . ' String'
 
   execute 'syn match markdownCodeBlockInListItemAtLevel' . (s:level) . ' '
     \ . 'contained contains=@NoSpell '
-    \ . '/' . (s:preceded_by_separator) . '\%(\%( \{' . (6+2*s:level)  . ',}\|\t\{' . (1+s:level) . ',}\).*\n\?\)\+$/'
+    \ . '/' . (s:preceded_by_separator) . '\%(\%( \{' . (g:markdown_indent_codeblock+g:markdown_indent_lenght*s:level)  . ',}\|\t\{' . (1+s:level) . ',}\).*\n\?\)\+$/'
   execute 'hi def link markdownCodeBlockInListItemAtLevel' . (s:level) . ' String'
 
   execute 'syn region markdownH1InListItemAtLevel' . (s:level) . ' '


### PR DESCRIPTION
Hello,
I made some changes to allow the use of syntax highlighting in nested blocks, if the indentation is 4 spaces and not two.
To do this, I added a global variable (`g:markdown_indent_lenght`) where to define the length of the indentation used.
The default behavior is not changed.