### PR TITLE
Fix issue #63, avoid taking a lot of time to parse code block

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -325,7 +325,7 @@ syn match markdownBlockquoteDelimiter /^\s*\%(>\s\?\)\+/ contained
 syn region markdownFencedCodeBlock matchgroup=markdownCodeDelimiter start=/^\s\{,3}```\%(`*\).*$/ end=/^\s\{,3}```\%(`*\)\s*$/ contains=@NoSpell
 syn region markdownFencedCodeBlock matchgroup=markdownCodeDelimiter start=/^\s\{,3}\~\~\~\%(\~*\).*$/ end=/^\s\{,3}\~\~\~\%(\~*\)\s*$/ contains=@NoSpell
 
-syn match markdownCodeBlock /\%(^\n\)\@<=\%(\%(\s\{4,}\|\t\+\).*\n\)\+$/ contains=@NoSpell
+syn match markdownCodeBlock /\%(^\n\)\@<=\%(\%( \{4}\|\t\+\).*\n\)\+$/ contains=@NoSpell
 
 let s:markdown_table_header_rows_separator = ''
   \ . '\%('


### PR DESCRIPTION
[Issue #63](https://github.com/gabrielelana/vim-markdown/issues/63)

Example:

```
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
      - foo
- bar
```