### PR TITLE
toggling behavior of checkbox

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -509,13 +509,20 @@ function! markdown#SwitchStatus()
     return
   endif
   if match(current_line, '^\s*[*\-+] \[x\]') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[x\]', '\1', ''))
+    if g:markdown_list_switch_order == "cycle"
+      call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[x\]', '\1', ''))
+    else
+      call setline('.', substitute(current_line, '^\(\s*[*\-+]\) \[x\]', '\1 [ ]', ''))
+    endif
     return
   endif
   if match(current_line, '^\s*[*\-+] \(\[[x ]\]\)\@!') >= 0
-    call setline('.', substitute(current_line, '^\(\s*[*\-+]\)', '\1 [ ]', ''))
+    if g:markdown_list_switch_order == "cycle"
+      call setline('.', substitute(current_line, '^\(\s*[*\-+]\)', '\1 [ ]', ''))
+    endif
     return
   endif
+
   if match(current_line, '^\s*#\{1,5}\s') >= 0
     call setline('.', substitute(current_line, '^\(\s*#\{1,5}\) \(.*$\)', '\1# \2', ''))
     return

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -40,6 +40,10 @@ if !exists('g:markdown_mapping_switch_status')
   let g:markdown_mapping_switch_status = '<space>'
 endif
 
+if !exists('g:markdown_list_switch_order')
+  let g:markdown_list_switch_order = 'cycle'  " or 'toggle'
+endif
+
 if !exists('g:markdown_enable_spell_checking')
   let g:markdown_enable_spell_checking = 1
 endif


### PR DESCRIPTION
Hi,
I prefer a toggling behavior (`- [ ]` <=> `- [x] `) rather than the default, three state cycling behavior (`- `, `- [ ]`, `- [x]`). so I added an option to switch it.
The default behavior is not changed.

